### PR TITLE
Pretty print index-pattern fields in diff

### DIFF
--- a/src/sources/Directory.ts
+++ b/src/sources/Directory.ts
@@ -83,7 +83,10 @@ function uglify(item: Exportable) {
     const exported = cloneDeep(item)
     switch(item.type) {
         case 'index-pattern':
-            exported.attributes.fields = JSON.stringify(item.attributes.fields)
+            // Guard against fields not being an object yet.
+            if(typeof exported.attributes.fields != 'string') {
+                exported.attributes.fields = JSON.stringify(item.attributes.fields)
+            }
     }
     return exported
 }

--- a/src/sources/Directory.ts
+++ b/src/sources/Directory.ts
@@ -3,6 +3,7 @@ import {Exportable, Syncable, SyncType} from "../types";
 import * as Bluebird from 'bluebird'
 import {flatten} from 'lodash'
 import * as fse from 'fs-extra'
+import {cloneDeep} from "lodash";
 
 export default class Directory implements Syncable {
     dir: string
@@ -19,8 +20,8 @@ export default class Directory implements Syncable {
 
         // Write the export files to the directory.
         await Bluebird.map(items, async (item) => {
-            const dir = `${this.dir}/${item.type}`
-            return fse.outputJSON(`${dir}/${item.id}.json`, item, {spaces: 4})
+            const exported = prettify(item)
+            return fse.outputJSON(`${this.dir}/${item.type}/${item.id}.json`, exported, {spaces: 4})
         });
         return items.length
     }
@@ -42,7 +43,10 @@ export default class Directory implements Syncable {
                 // Filter out directories.
                 .then(files => files.filter(file => fse.statSync(file).isFile()))
                 // Read the JSON from the files.
-                .then(files => Bluebird.map(files, f => fse.readJSON(f)))
+                .then(files => Bluebird.map(files, async (f) => {
+                    const item = await fse.readJSON(f)
+                    return uglify(item)
+                }))
         }) .then(flatten)
     }
 
@@ -52,4 +56,34 @@ export default class Directory implements Syncable {
             return fse.unlink(filename)
         })
     }
+}
+
+/**
+ * Act on exportables right before they're saved to clean them up and make them
+ * diffable.
+ *
+ * @param item
+ */
+function prettify(item: Exportable) {
+    const exported = cloneDeep(item)
+    switch(item.type) {
+        case 'index-pattern':
+            exported.attributes.fields = JSON.parse(item.attributes.fields)
+    }
+    return exported
+}
+
+/**
+ * Act on exportables right after they're ready to convert them back into standard
+ * Kibana format.
+ *
+ * @param item
+ */
+function uglify(item: Exportable) {
+    const exported = cloneDeep(item)
+    switch(item.type) {
+        case 'index-pattern':
+            exported.attributes.fields = JSON.stringify(item.attributes.fields)
+    }
+    return exported
 }


### PR DESCRIPTION
This PR starts to address exports to make them more diff-able.  Specifically, index-patterns seem to change a lot in the `attributes.fields` property, but this field is a serialized JSON export that gets printed in the JSON export as a single line.  This PR unserializes the `attributes.fields` property of index patterns immediately before they get written to the file, and reserializes it before it's sent off for comparison or import. 